### PR TITLE
Added a guard for added negative amounts

### DIFF
--- a/app/Domain/Account/AccountAggregateRoot.php
+++ b/app/Domain/Account/AccountAggregateRoot.php
@@ -31,8 +31,16 @@ final class AccountAggregateRoot extends AggregateRoot
 
     public function addMoney(int $amount)
     {
-        $this->recordThat(new MoneyAdded($amount));
-
+        if($this->ammountAddedIsNegative($amount)) {
+            
+            $this->subtractMoney($amount)
+                
+        } else {
+            
+            $this->recordThat(new MoneyAdded($amount));        
+            
+        }
+        
         return $this;
     }
 
@@ -90,4 +98,10 @@ final class AccountAggregateRoot extends AggregateRoot
     {
         return $this->accountLimitHitInARow >= 3;
     }
+    
+    private function ammountAddedIsNegative(int $amount): bool
+    {
+        return $amount < 0;
+    }
+    
 }

--- a/app/Domain/Account/AccountAggregateRoot.php
+++ b/app/Domain/Account/AccountAggregateRoot.php
@@ -33,7 +33,7 @@ final class AccountAggregateRoot extends AggregateRoot
     {
         if($this->ammountAddedIsNegative($amount)) {
             
-            $this->subtractMoney($amount)
+            $this->subtractMoney($amount);
                 
         } else {
             


### PR DESCRIPTION
Aggregates are consistency boundaries and ensures the consistency of the Domain. Right now it is possible to add -1000, which will store an MoneyAdded, which substracts money. This fix will make sure that negative amounts will always fire a MoneySubstracted and validate it's invariants. This can also be fixed in the user interface, but the whole point of an Aggregate is that is does not care about the outside world when it comes to it's own rules.

![image](https://user-images.githubusercontent.com/1174877/55982106-73da9500-5c98-11e9-8cfd-3bd8515d858c.png)

This is not a real solution. It needs to be validated before. In the user interface or maybe the FormRequests... 
