### PR TITLE
Fix using Str::uuid

### DIFF
--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -20,7 +20,7 @@ class AccountsController extends Controller
 
     public function store(Request $request)
     {
-        $newUuid = Str::uuid();
+        $newUuid = Str::uuid()->toString();
 
         AccountAggregateRoot::retrieve($newUuid)
             ->createAccount($request->name, auth()->user()->id)


### PR DESCRIPTION
Using Illuminate\Support\Str::uuid() will return a 'Ramsey\Uuid\UuidInterface' causing  an error since the aggregate retrieve function it expects an array