### PR TITLE
Make account balance and limits public properties to fix creating snapshots

### DIFF
--- a/app/Domain/Account/AccountAggregateRoot.php
+++ b/app/Domain/Account/AccountAggregateRoot.php
@@ -13,11 +13,11 @@ use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 
 class AccountAggregateRoot extends AggregateRoot
 {
-    protected int $balance = 0;
+    public int $balance = 0;
 
     protected int $accountLimit = -5000;
 
-    protected int $accountLimitHitInARow = 0;
+    public int $accountLimitHitInARow = 0;
 
     public function createAccount(string $name, string $userId)
     {


### PR DESCRIPTION
When creating snapshots, the default method of ```getState``` is used, which uses reflections to get *only* ```public``` properties of the aggregate, and in this case returns an empty array.

Making the properties protected/private essentially makes the aggregate snapshot useless, since it won't include any state. And results in a disconnect between the visible state and the system state.
